### PR TITLE
add ability to customize leading point width and leading point indent…

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -31,6 +31,8 @@ export 'src/editor/style_widgets/style_widgets.dart';
 export 'src/editor/widgets/cursor.dart';
 export 'src/editor/widgets/default_styles.dart';
 export 'src/editor/widgets/link.dart';
+export 'src/editor/widgets/text/text_block.dart'
+    show TextBlockUtils, LeadingBlockIndentWidth, LeadingBlockNumberPointWidth;
 export 'src/editor_toolbar_controller_shared/copy_cut_service/copy_cut_service.dart';
 export 'src/editor_toolbar_controller_shared/copy_cut_service/copy_cut_service_provider.dart';
 export 'src/editor_toolbar_controller_shared/copy_cut_service/default_copy_cut_service.dart';

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -6,6 +6,7 @@ import '../../common/utils/platform.dart';
 import '../../document/attribute.dart';
 import '../../document/style.dart';
 import '../style_widgets/checkbox_point.dart';
+import 'text/text_block.dart';
 
 class QuillStyles extends InheritedWidget {
   const QuillStyles({
@@ -160,10 +161,15 @@ class DefaultListBlockStyle extends DefaultTextBlockStyle {
     super.verticalSpacing,
     super.lineSpacing,
     super.decoration,
-    this.checkboxUIBuilder,
-  );
+    this.checkboxUIBuilder, {
+    this.indentWidthBuilder = TextBlockUtils.defaultIndentWidthBuilder,
+    this.numberPointWidthBuilder =
+        TextBlockUtils.defaultNumberPointWidthBuilder,
+  });
 
   final QuillCheckboxBuilder? checkboxUIBuilder;
+  final LeadingBlockIndentWidth indentWidthBuilder;
+  final LeadingBlockNumberPointWidth numberPointWidthBuilder;
 }
 
 @immutable

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -157,6 +157,12 @@ class EditableTextBlock extends StatelessWidget {
   List<Widget> _buildChildren(BuildContext context,
       Map<int, int> indentLevelCounts, bool clearIndents) {
     final defaultStyles = QuillStyles.getStyles(context, false);
+    final numberPointWidthBuilder =
+        defaultStyles?.lists?.numberPointWidthBuilder ??
+            TextBlockUtils.defaultNumberPointWidthBuilder;
+    final indentWidthBuilder = defaultStyles?.lists?.indentWidthBuilder ??
+        TextBlockUtils.defaultIndentWidthBuilder;
+
     final count = block.children.length;
     final children = <Widget>[];
     if (clearIndents) {
@@ -187,7 +193,7 @@ class EditableTextBlock extends StatelessWidget {
           customLinkPrefixes: customLinkPrefixes,
           customRecognizerBuilder: customRecognizerBuilder,
         ),
-        _getIndentWidth(context, count),
+        indentWidthBuilder(block, context, count, numberPointWidthBuilder),
         _getSpacingForLine(line, index, count, defaultStyles),
         textDirection,
         textSelection,
@@ -208,20 +214,6 @@ class EditableTextBlock extends StatelessWidget {
     return children.toList(growable: false);
   }
 
-  double _numberPointWidth(double fontSize, int count) {
-    final length = '$count'.length;
-    switch (length) {
-      case 1:
-      case 2:
-        return fontSize * 2;
-      default:
-        // 3 -> 2.5
-        // 4 -> 3
-        // 5 -> 3.5
-        return fontSize * (length - (length - 2) / 2);
-    }
-  }
-
   Widget? _buildLeading({
     required BuildContext context,
     required Line line,
@@ -232,6 +224,9 @@ class EditableTextBlock extends StatelessWidget {
     final defaultStyles = QuillStyles.getStyles(context, false)!;
     final fontSize = defaultStyles.paragraph?.style.fontSize ?? 16;
     final attrs = line.style.attributes;
+    final numberPointWidthBuilder =
+        defaultStyles.lists?.numberPointWidthBuilder ??
+            TextBlockUtils.defaultNumberPointWidthBuilder;
 
     // Of the color button
     final fontColor =
@@ -298,7 +293,7 @@ class EditableTextBlock extends StatelessWidget {
                       color: defaultStyles.code!.style.color!.withOpacity(0.4),
                     ),
       width: isOrdered || isCodeBlock
-          ? _numberPointWidth(fontSize, count)
+          ? numberPointWidthBuilder(fontSize, count)
           : isUnordered
               ? fontSize * 2
               : null,
@@ -340,35 +335,6 @@ class EditableTextBlock extends StatelessWidget {
       return codeBlockLineNumberLeading(leadingConfigurations);
     }
     return null;
-  }
-
-  HorizontalSpacing _getIndentWidth(BuildContext context, int count) {
-    final defaultStyles = QuillStyles.getStyles(context, false)!;
-    final fontSize = defaultStyles.paragraph?.style.fontSize ?? 16;
-    final attrs = block.style.attributes;
-
-    final indent = attrs[Attribute.indent.key];
-    var extraIndent = 0.0;
-    if (indent != null && indent.value != null) {
-      extraIndent = fontSize * indent.value;
-    }
-
-    if (attrs.containsKey(Attribute.blockQuote.key)) {
-      return HorizontalSpacing(fontSize + extraIndent, 0);
-    }
-
-    var baseIndent = 0.0;
-
-    if (attrs.containsKey(Attribute.list.key)) {
-      baseIndent = fontSize * 2;
-      if (attrs[Attribute.list.key] == Attribute.ol) {
-        baseIndent = _numberPointWidth(fontSize, count);
-      } else if (attrs.containsKey(Attribute.codeBlock.key)) {
-        baseIndent = _numberPointWidth(fontSize, count);
-      }
-    }
-
-    return HorizontalSpacing(baseIndent + extraIndent, 0);
   }
 
   VerticalSpacing _getSpacingForLine(
@@ -798,5 +764,65 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
       ..setPadding(_padding)
       ..decoration = decoration
       ..contentPadding = _contentPadding;
+  }
+}
+
+typedef LeadingBlockIndentWidth = HorizontalSpacing Function(
+    Block block,
+    BuildContext context,
+    int count,
+    LeadingBlockNumberPointWidth numberPointWidthDelegate);
+
+typedef LeadingBlockNumberPointWidth = double Function(
+    double fontSize, int count);
+
+class TextBlockUtils {
+  TextBlockUtils._();
+
+  static HorizontalSpacing defaultIndentWidthBuilder(
+      Block block,
+      BuildContext context,
+      int count,
+      LeadingBlockNumberPointWidth numberPointWidthBuilder) {
+    final defaultStyles = QuillStyles.getStyles(context, false)!;
+    final fontSize = defaultStyles.paragraph?.style.fontSize ?? 16;
+    final attrs = block.style.attributes;
+
+    final indent = attrs[Attribute.indent.key];
+    var extraIndent = 0.0;
+    if (indent != null && indent.value != null) {
+      extraIndent = fontSize * indent.value;
+    }
+
+    if (attrs.containsKey(Attribute.blockQuote.key)) {
+      return HorizontalSpacing(fontSize + extraIndent, 0);
+    }
+
+    var baseIndent = 0.0;
+
+    if (attrs.containsKey(Attribute.list.key)) {
+      baseIndent = fontSize * 2;
+      if (attrs[Attribute.list.key] == Attribute.ol) {
+        baseIndent = numberPointWidthBuilder(fontSize, count);
+      } else if (attrs.containsKey(Attribute.codeBlock.key)) {
+        baseIndent = numberPointWidthBuilder(fontSize, count);
+      }
+    }
+
+    return HorizontalSpacing(baseIndent + extraIndent, 0);
+  }
+
+  static double defaultNumberPointWidthBuilder(double fontSize, int count) {
+    final length = '$count'.length;
+    switch (length) {
+      case 1:
+      case 2:
+        return fontSize * 2;
+      default:
+        // 3 -> 2.5
+        // 4 -> 3
+        // 5 -> 3.5
+        return fontSize * (length - (length - 2) / 2);
+    }
   }
 }

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -295,7 +295,7 @@ class EditableTextBlock extends StatelessWidget {
       width: isOrdered || isCodeBlock
           ? numberPointWidthBuilder(fontSize, count)
           : isUnordered
-              ? fontSize * 2
+              ? numberPointWidthBuilder(fontSize, 1) // same as fontSize * 2
               : null,
       padding: isOrdered || isUnordered
           ? fontSize / 2


### PR DESCRIPTION
closes #2131

## Description of changes

- add `indentWidthBuilder` and `numberPointWidthBuilder` to `DefaultListBlockStyle`.
- extract default indent and point number width calculation logic to static methods under `TextBlockUtils`
- expose `LeadingBlockIndentWidth`, `LeadingBlockNumberPointWidth` and `TextBlockUtils` from `text_block.dart`